### PR TITLE
Fixed failed verification during registration

### DIFF
--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -51,7 +51,7 @@ router.post('/register', function(req, res) {
     user.email = req.body.email;
 
     console.log("makes it here");
-    //res.clearCookie('auth');
+    
 
     var cookie = req.cookies.auth;
 
@@ -125,7 +125,7 @@ router.post('/deleteaccount', function(req, res) {
 //logout
 router.get('/logout', function(req, res) {
     //clear token
-    res.cookie('auth', "");
+    res.clearCookie('auth');
     res.redirect('/');
 })
 


### PR DESCRIPTION
Fixes #6

In `/logout` route `res.cookie('auth', "");`  was setting an empty cookie instead of clearing it.

Changed it to clear the cookie: `res.clearCookie('auth');`

